### PR TITLE
add succinct property to constructor options

### DIFF
--- a/lib/Reporter.js
+++ b/lib/Reporter.js
@@ -11,6 +11,7 @@ function Reporter(options){
   this._passed = 0;
   this._progress = 0;
   this._started = null;
+  this._succinct = options.runner._options.succinct;
 
   this._runner.on('start', this._start.bind(this));
   this._runner.on('fileComplete', this._fileComplete.bind(this));
@@ -31,10 +32,12 @@ Reporter.prototype._fileComplete = function(err, file, output){
   if( err ) {
     this._failed++;
 
-    console.log(sty.yellow('\n' + 'node ' + file + '\n' + helper.strRepeat('=', file.length + 5)));
-    output.forEach(function(line){ // Write each line from the child process
-      console.log(sty.bold(line.data));
-    });
+    if(!this._succinct) {
+      console.log(sty.yellow('\n' + 'node ' + file + '\n' + helper.strRepeat('=', file.length + 5)));
+      output.forEach(function(line){ // Write each line from the child process
+        console.log(sty.bold(line.data));
+      });
+    }
   } else {
     this._passed++;
   }

--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -8,7 +8,6 @@ var helper = require('./helper.js');
 util.inherits(Antr, EventEmitter);
 
 function Antr (options, cb) {
-  var self = this;
   this._cb = cb || null;
 
   options = options || {};
@@ -18,7 +17,8 @@ function Antr (options, cb) {
     batchSize: options.batchSize || 8,
     timeout: (isNaN(parseInt(options.timeout)) )? 30000 : parseInt(options.timeout) * 1000,
     listFiles: options.listFiles || false,
-    progressBar: (options.progressBar == false) ? false : true
+    progressBar: (options.progressBar == false) ? false : true,
+    succinct: options.succinct || 0
   }
   this._stats = {
     failed: 0,


### PR DESCRIPTION
Remove unused self var

You can now add a new property to options passed in to the constructor

``` js
  new Antr({
    dirname: [__dirname + '/../test/unit', __dirname + '/../test/app'],
    filter: undefined,
    batchSize: 1,
    timeout: 60,
    succinct: 1,
    progressBar: false
  }, function (err, stats) {
    if( err ) {
      return cb({status_code: 417, error: stats});
    } else {
      return cb(null, {status_code:200, data:stats});
    }
  });
```

So that we limit the amount of info placed on stdout/stderr
