### PR TITLE
Log the tests after sorting them

### DIFF
--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -127,8 +127,8 @@ Antr.prototype.getFiles = function (cb) {
   async.map(dirs, this.findFiles.bind(this), function(err, results){
     results = results.filter(function(n){return n;});
     var files = helper.concatArray(results);
-    if( self._options.listFiles ) console.log('Files going to be run: ', files);
     if( self._options.sort ) files = files.sort(self._options.sort);
+    if( self._options.listFiles ) console.log('Files going to be run: ', files);
     cb(null, files);
   });
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sty": "0.6.1"
   },
   "devDependencies": {
-    "sinon": "^1.15.4",
+    "sinon": "1.15.4",
     "underscore": "1.4.4"
   },
   "author": "Joe Warren <joe.warren@holidayextras.com>,Jack Cannon <jack.cannon@holidayextras.com>",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "sty": "0.6.1"
   },
   "devDependencies": {
+    "sinon": "^1.15.4",
     "underscore": "1.4.4"
   },
   "author": "Joe Warren <joe.warren@holidayextras.com>,Jack Cannon <jack.cannon@holidayextras.com>",

--- a/test/unit/testRunner.js
+++ b/test/unit/testRunner.js
@@ -1,5 +1,6 @@
 var Runner = require('../../lib/Runner.js');
 var assert = require('assert');
+var sinon = require('sinon');
 
 (function () {
   var runner = new Runner({
@@ -54,12 +55,14 @@ var assert = require('assert');
   var runner = new Runner({
     dirname: ['test/files', 'test/sorting'],
     filter: /run([^\/w]+?)\.js$/,
+    listFiles: true,
     sort: function(leftPath, rightPath) {
       var leftFilename = leftPath.split('/').slice(-1)[0];
       var rightFilename = rightPath.split('/').slice(-1)[0];
       return (leftFilename > rightFilename) ? 1 : -1;
     }
   });
+  sinon.spy(console, 'log');
 
   runner.getFiles(function(err, files){
 
@@ -71,5 +74,7 @@ var assert = require('assert');
     ];
 
     assert.deepEqual(files, expectedPaths);
+    assert.ok(console.log.calledWith('Files going to be run: ', expectedPaths));
+    console.log.restore();
   });
 })();


### PR DESCRIPTION
Tried out #11 on another project, thought it didn't work -- it did, but the logging with `listFiles` option misleads by logging the unsorted list.

I've moved the sorting to above the logging.